### PR TITLE
Support multiple environments that require a prompt before anonymizing.

### DIFF
--- a/config/anonymizer.php
+++ b/config/anonymizer.php
@@ -3,5 +3,17 @@
 return [
     'locale' => 'en_US',
     'chunk_size' => 1000,
-    'models_path' => app_path('Models')
+    'models_path' => app_path('Models'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Blocked Environments
+    |--------------------------------------------------------------------------
+    |
+    | Support multiple environments that require a prompt before anonymizing.
+    | By default the listed blocked environments are forcibly blocked for extra safety.
+    |
+    */
+    'blocked_env' => ['production'],
+    'force_blocked_env' => true,
 ];

--- a/src/Anonymizer.php
+++ b/src/Anonymizer.php
@@ -19,6 +19,11 @@ class Anonymizer
         );
     }
 
+    public function isBlockedEnvironment(): bool
+    {
+        return in_array(config('app.env'), config('anonymizer.blocked_env', []));
+    }
+
     private function getAllModels(): array
     {
         return File::allFiles(config('anonymizer.models_path', app_path('Models')));
@@ -63,6 +68,10 @@ class Anonymizer
 
     public function changeData(Model $model): bool
     {
+        if ($this->isBlockedEnvironment() && config('anonymizer.force_blocked_env', true)) {
+            throw new \Exception(sprintf("Environment '%s' has blocking enforced.", config('app.env')));
+        }
+
         return $model
             ->setTouchedRelations([]) // disable touch owners
             ->updateQuietly( // disable events handling

--- a/src/Commands/AnonymizerCommand.php
+++ b/src/Commands/AnonymizerCommand.php
@@ -35,7 +35,9 @@ class AnonymizerCommand extends Command
 
     public function handle(): int
     {
-        if (! $this->confirmToProceed()) {
+        if (!$this->confirmToProceed('Environment "'.config('app.env').'" blocked.', function () {
+            return $this->service->isBlockedEnvironment();
+        })) {
             return 0;
         }
 


### PR DESCRIPTION
two features
1. Support multiple environments that require a prompt before anonymising.
2. extra safety - forcibly block anonymisation for the listed blocked environments 