### PR TITLE
Handle the case where a model does not have withTrashed

### DIFF
--- a/src/Anonymizable.php
+++ b/src/Anonymizable.php
@@ -10,8 +10,9 @@ trait Anonymizable
 {
     public function anonymizableCondition(): Builder
     {
-        return static::withTrashed();
+        return static::hasMacro('withTrashed') ? static::withTrashed() : static::query();
     }
+
     public function anonymizableAttributes(Generator $faker): array
     {
         throw new LogicException('Please implement the anonymizable method on your model.');


### PR DESCRIPTION
Provides a better default experience without overriding `anonymizableCondition()`