### PR TITLE
 Create a new instance of Anonymizer in handle method of command

### DIFF
--- a/src/Commands/AnonymizerCommand.php
+++ b/src/Commands/AnonymizerCommand.php
@@ -25,16 +25,10 @@ class AnonymizerCommand extends Command
 
     private Anonymizer $service;
 
-
-    public function __construct()
-    {
-        parent::__construct();
-
-        $this->service = new Anonymizer();
-    }
-
     public function handle(): int
     {
+        $this->service = new Anonymizer();
+
         if (!$this->confirmToProceed('Environment "'.config('app.env').'" blocked.', function () {
             return $this->service->isBlockedEnvironment();
         })) {


### PR DESCRIPTION
Create a new instance of Anonymizer only before the command actually will be handled. This prevents the Anonymizer class to create a new Faker instance which will fail on many production environments.

In our production environment, Faker isn't installed because Faker is in require-dev. 
