### PR TITLE
Allow anonymization based on Model's factory definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ return [
 
 ## Usage
 
-In any model that contains sensitive data use `Anonymizable` trait and implement `anonymizableAttributes` method:
+### Model based definitions
+In any model that contains sensitive data use the `Anonymizable` trait and implement the `anonymizableAttributes` method:
 
 ```php
 <?php
@@ -50,10 +51,10 @@ class User extends Authenticatable
         return [
             'email' => $this->id . '@custom.dev',
             'password' => 'secret',
-            'firstname' => $faker->firstName,
-            'surname' => $faker->lastName,
-            'phone' => $faker->e164PhoneNumber,
-            'position' => $faker->jobTitle,
+            'firstname' => $faker->firstName(),
+            'surname' => $faker->lastName(),
+            'phone' => $faker->e164PhoneNumber(),
+            'position' => $faker->jobTitle(),
             'token' => null,
         ];
     }
@@ -65,6 +66,133 @@ class User extends Authenticatable
     }
 }
 ```
+
+### Factory based definitions
+To reduce the amount of necessary code, the anonymizable attributes may also be defined on your factories. 
+Do note that the model still needs to implement the `Anonymizable` to work with these definitions.
+
+#### Attributes based on the factory's definition
+It is possible to use the factory's definition to use as anonymizable values. 
+Implement the `anonymizableAttributes` method on your factory and return an array with keys that corresponds to the definition of the factory:
+
+```php
+<?php
+
+class UserFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'email' => $this->faker()->numberBetween(1, 100_000) . '@custom.dev',
+            'password' => 'secret',
+            'firstname' => $this->faker->firstName(),
+            'surname' => $this->faker->lastName(),
+            'phone' => $this->faker->e164PhoneNumber(),
+            'position' => $this->faker->jobTitle(),
+            'token' => null,
+        ]
+    }
+    
+    public function anonymizableAttributes(): array
+    {
+        return [
+            'email',
+            'password',
+            'firstname',
+            'surname',
+            'phone',
+            'position',
+            'token',
+        ]
+    }
+}
+```
+This will use reduce the amount of code you need to write if the data you want to anonymize is the same as your factory's definition.
+
+Note that only the defined keys will be anonymized!
+
+#### Attributes based on a custom definition
+If you prefer to still use custom values, you can still define them on the factory. 
+Implement the `anonymizableDefinition` method on your factory, and return a keyed array:
+
+```php
+<?php
+
+class UserFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'email' => $this->faker()->numberBetween(1, 100_000) . '@custom.dev',
+            'password' => 'secret',
+            'firstname' => $faker->firstName(),
+            'surname' => $faker->lastName(),
+            'phone' => $faker->e164PhoneNumber(),
+            'position' => $faker->jobTitle(),
+            'token' => null,
+        ]
+    }
+    
+    public function anonymizableDefinition(): array
+    {
+        return [
+            'email' => $this->faker()->numberBetween(1, 100_000) . '@custom.dev',
+            'password' => 'secret',
+            'firstname' => $faker->firstName(),
+            'surname' => $faker->lastName(),
+            'phone' => $faker->e164PhoneNumber(),
+            'position' => $faker->jobTitle(),
+            'token' => $this->faker->md5(),
+        ]
+    }
+}
+```
+
+Defining custom values is mostly useful when used in tandem with the `anonymizableAttributes` method. 
+This allows certain attributes from the factory to be used, while still defining custom attributes when necessary:
+```php
+<?php
+
+class UserFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'email' => $this->faker()->numberBetween(1, 100_000) . '@custom.dev',
+            'password' => 'secret',
+            'firstname' => $faker->firstName(),
+            'surname' => $faker->lastName(),
+            'phone' => $faker->e164PhoneNumber(),
+            'position' => $faker->jobTitle(),
+            'token' => null,
+        ]
+    }
+    
+    public function anonymizableAttributes(): array
+    {
+        return [
+            'email',
+            'password',
+            'firstname',
+            'surname',
+            'phone',
+            'position',
+        ]
+    }
+    
+    public function anonymizableDefinition(): array
+    {
+        return [
+            'token' => $this->faker->md5(),
+        ]
+    }
+}
+```
+
+### Important note
+>The data from the `anonymizable` methods on the factory will overwrite the data defined in the  `anonymizableAttributes` method on the model!
+
+### Running the anonymizer
 Anonymization is performed using command:
 
 ```bash

--- a/src/Anonymizable.php
+++ b/src/Anonymizable.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Outsidaz\LaravelDataAnonymization;;
+namespace Outsidaz\LaravelDataAnonymization;
 
 use Faker\Generator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use LogicException;
 
 trait Anonymizable
@@ -15,6 +16,19 @@ trait Anonymizable
 
     public function anonymizableAttributes(Generator $faker): array
     {
-        throw new LogicException('Please implement the anonymizable method on your model.');
+        $class = new (static::class)();
+
+        if (! is_subclass_of($class, Model::class)) {
+            throw new LogicException('Please implement the anonymizable trait on an Eloquent Model.');
+        }
+
+        // Check if the model's factory has an implementation of the anonymizable attributes that the anonymizer can use
+        if ($class::factory()) {
+            if (method_exists($class::factory(), 'anonymizableAttributes')) {
+                return [];
+            }
+        }
+
+        throw new LogicException('Please implement the anonymizable method on your model or the factory.');
     }
 }

--- a/src/Anonymizable.php
+++ b/src/Anonymizable.php
@@ -29,6 +29,8 @@ trait Anonymizable
             }
         }
 
-        throw new LogicException('Please implement the anonymizable method on your model or the factory.');
+        throw new LogicException(
+            'Please implement the anonymizableAttributes() method on your model or the model\'s factory.'
+        );
     }
 }

--- a/src/Anonymizer.php
+++ b/src/Anonymizer.php
@@ -72,10 +72,16 @@ class Anonymizer
             throw new \Exception(sprintf("Environment '%s' has blocking enforced.", config('app.env')));
         }
 
+        $anonymizableAttributes = $model->anonymizableAttributes($this->faker);
+
+        if (method_exists($model::factory(), 'anonymizableAttributes')) {
+            $anonymizableAttributes = $model::factory()->anonymizableAttributes($this->faker);
+        }
+
         return $model
             ->setTouchedRelations([]) // disable touch owners
             ->updateQuietly( // disable events handling
-                $model->anonymizableAttributes($this->faker)
+                $anonymizableAttributes
             );
     }
 }


### PR DESCRIPTION
I wanted to implement this package in our projects, but we found registrering the fields to anonymize on the model to be a bit of double work, as model factories already have a definition that forms a base for using synthetic data.

These changes allow developers to register the attributes to anonymize on the model's factory. Furthermore, it allows to use the definition that already exists, or to create a custom definition that will only be used when running the anonymize command. I've updated the readme to reflect on these changes.

I've tried to match the codestyling and conventions already used in this package, but please let me know if something is off, or if these changes aren't desired for this package.