### PR TITLE
Support pure-trait anonymization: recursive trait detection + optional factory

### DIFF
--- a/src/Anonymizer.php
+++ b/src/Anonymizer.php
@@ -76,11 +76,19 @@ class Anonymizer
         $anonymizableAttributesBasedOnFactoryDefinition = [];
         $anonymizableAttributesBasedOnCustomDefinition = [];
 
-        /** @var \Illuminate\Database\Eloquent\Factories\Factory $factory */
-        $factory = $model::factory();
+        /** @var \Illuminate\Database\Eloquent\Factories\Factory|null $factory */
+        $factory = null;
+        if (method_exists($model, 'factory')) {
+            try {
+                $factory = $model::factory();
+            } catch (\Throwable) {
+                // Model uses HasFactory but no factory class exists — the anonymization
+                // data still comes from the model's Anonymizable trait, so proceed.
+            }
+        }
 
         // Extract attributes, including values, from the factory's definition, if available
-        if (method_exists($factory, 'anonymizableAttributes')) {
+        if ($factory && method_exists($factory, 'anonymizableAttributes')) {
             $anonymizableAttributesKeys = $factory->anonymizableAttributes();
             $factoryDefinition = $factory->definition();
 
@@ -93,7 +101,7 @@ class Anonymizer
         }
 
         // Extract attributes and values from the custom definition, if available
-        if (method_exists($factory, 'anonymizableDefinition')) {
+        if ($factory && method_exists($factory, 'anonymizableDefinition')) {
             $anonymizableAttributesBasedOnCustomDefinition = $factory->anonymizableDefinition($this->faker);
         }
 

--- a/src/Anonymizer.php
+++ b/src/Anonymizer.php
@@ -44,7 +44,7 @@ class Anonymizer
     {
         return array_filter(
             $this->getAllClasses(),
-            fn($class) => in_array(Anonymizable::class, class_uses($class), true)
+            fn($class) => in_array(Anonymizable::class, class_uses_recursive($class), true)
         );
     }
 


### PR DESCRIPTION
Hey 👋

Was setting up the package for a project and hit two things that block the "everything on the model side" workflow. Two small commits, both aimed at the same goal — letting a model own its full anonymization contract via a wrapper trait, with no factory required.

## 1. `class_uses` → `class_uses_recursive` in the discovery filter

`Anonymizer::getAnonymizableClasses()` uses `class_uses()`, which only returns traits used **directly** on the class. It doesn't walk into traits that themselves use other traits.

So a natural pattern where each model gets its own trait (say `AnonymizableUser`) that internally `use`s `Anonymizable` and declares the `anonymizableAttributes()` — with the model just writing `use AnonymizableUser;` — silently gets skipped by the anonymizer. `class_uses_recursive` walks the whole trait hierarchy and finds `Anonymizable` either way. Direct uses of `Anonymizable` keep working exactly as before.

## 2. Make factory resolution optional in `changeData()`

Right now `changeData()` calls `$model::factory()` unconditionally. If the model has no factory class, this throws before the model's own `anonymizableAttributes()` from the trait can even run — so a model that fully defines its anonymization on its own trait still breaks at runtime.

Wrapping the factory resolution in `method_exists` + `try/catch` lets:

- models with a factory keep the existing behavior,
- models without one still get anonymized from the trait alone.

## Together

The two changes are the minimum needed to run the trait-only pattern end to end. Neither changes behavior for anyone who already uses the package the documented way.

Would be great if these could get merged 🙏